### PR TITLE
Implement Issue #7: bootstrap interactive table app and CI automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
-.PHONY: setup ci test lint fmt dev
+.PHONY: setup ci test lint fmt build dev
 
 setup:
-	@echo "TODO: install dependencies (Codex should define this once stack is chosen)"
+	npm ci
 
 fmt:
-	@echo "TODO: formatting"
+	npm run fmt
 
 lint:
-	@echo "TODO: linting"
+	npm run lint
 
 test:
-	@echo "TODO: tests"
+	npm run test
 
-ci: fmt lint test
-	@echo "CI completed (placeholder)"
+build:
+	npm run build
+
+ci: setup fmt lint test build
+
+# serves the static build output
+dev: build
+	python3 -m http.server 4173 --directory dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # interactive-table-codex
+
+Minimal static frontend app demonstrating a sortable and filterable table.
+
+## Commands
+- `make setup`
+- `make fmt`
+- `make lint`
+- `make test`
+- `make build`
+- `make ci`
+- `make dev`

--- a/docs/evidence/ISSUE-7-interactive-table-bootstrap.md
+++ b/docs/evidence/ISSUE-7-interactive-table-bootstrap.md
@@ -1,0 +1,28 @@
+# Evidence Pack — Issue #7 interactive table bootstrap
+
+## What changed
+- Replaced placeholder Makefile targets with working `setup`, `fmt`, `lint`, `test`, `build`, `ci`, and `dev` commands.
+- Bootstrapped a static frontend app under `src/` with a sortable and filterable table UI.
+- Added build/lint/format scripts and a smoke test for table sorting behavior.
+- Added `.gitignore` and npm project metadata for reproducible local/CI runs.
+
+## Why
+- Issue #7 requires a mergeable vertical slice with runnable static frontend behavior and CI automation wired to `make ci`.
+
+## How to verify
+### Automated
+- `make ci`:
+  - Result: pass
+  - Notes: npm emits a non-failing warning about unknown env config `http-proxy`; all required checks succeed.
+
+### Manual (if needed)
+- Steps:
+  1. Run `make dev`.
+  2. Open `http://localhost:4173`.
+  3. Use the search box to filter rows and click `Name`/`City` headers to sort.
+- Expected: rows update immediately based on filter/sort actions.
+
+## Risk assessment
+- Risk level: low
+- Potential regressions: static assets may not include future nested paths if build script assumptions change.
+- Rollback plan: revert this PR commit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "interactive-table-codex",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "interactive-table-codex",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "interactive-table-codex",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "setup": "npm ci",
+    "fmt": "node scripts/fmt.mjs",
+    "lint": "node scripts/lint.mjs",
+    "test": "node --test",
+    "build": "node scripts/build.mjs",
+    "dev": "npm run build && python3 -m http.server 4173 --directory dist"
+  }
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,5 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+
+await rm("dist", { recursive: true, force: true });
+await mkdir("dist", { recursive: true });
+await cp("src", "dist", { recursive: true });

--- a/scripts/fmt.mjs
+++ b/scripts/fmt.mjs
@@ -1,0 +1,26 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(path);
+      return path;
+    })
+  );
+  return files.flat();
+};
+
+const files = await walk("src");
+const offenders = [];
+for (const file of files) {
+  const text = await readFile(file, "utf8");
+  if (!text.endsWith("\n")) offenders.push(`${file}: missing trailing newline`);
+}
+
+if (offenders.length) {
+  console.error(offenders.join("\n"));
+  process.exit(1);
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,32 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(path);
+      return path;
+    })
+  );
+  return files.flat();
+};
+
+const files = (await walk("src")).filter((file) => file.endsWith(".js") || file.endsWith(".html"));
+const violations = [];
+
+for (const file of files) {
+  const text = await readFile(file, "utf8");
+  if (text.includes("\t")) {
+    violations.push(`${file}: contains tab characters`);
+  }
+  if (text.includes("console.log(")) {
+    violations.push(`${file}: contains console.log`);
+  }
+}
+
+if (violations.length) {
+  console.error(violations.join("\n"));
+  process.exit(1);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Interactive Table</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Interactive Table</h1>
+      <label for="search">Filter rows</label>
+      <input id="search" type="search" placeholder="Type to filter by name or city" />
+      <table>
+        <thead>
+          <tr>
+            <th><button id="sortName" type="button">Name</button></th>
+            <th>Role</th>
+            <th><button id="sortCity" type="button">City</button></th>
+          </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </main>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,60 @@
+const people = [
+  { name: "Ari", role: "Engineer", city: "Seattle" },
+  { name: "Bea", role: "Designer", city: "Austin" },
+  { name: "Cam", role: "PM", city: "Boston" },
+  { name: "Dia", role: "Engineer", city: "Chicago" }
+];
+
+const state = {
+  sortBy: "name",
+  query: ""
+};
+
+export const getVisibleRows = (rows, query, sortBy) =>
+  rows
+    .filter((row) => {
+      const haystack = `${row.name} ${row.city}`.toLowerCase();
+      return haystack.includes(query.trim().toLowerCase());
+    })
+    .toSorted((a, b) => a[sortBy].localeCompare(b[sortBy]));
+
+export const renderRows = (rows, target) => {
+  target.innerHTML = rows
+    .map((row) => `<tr><td>${row.name}</td><td>${row.role}</td><td>${row.city}</td></tr>`)
+    .join("");
+};
+
+const init = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const tableBody = document.querySelector("#tableBody");
+  const search = document.querySelector("#search");
+  const sortName = document.querySelector("#sortName");
+  const sortCity = document.querySelector("#sortCity");
+
+  if (!tableBody || !search || !sortName || !sortCity) {
+    return;
+  }
+
+  const refresh = () => renderRows(getVisibleRows(people, state.query, state.sortBy), tableBody);
+
+  search.addEventListener("input", (event) => {
+    state.query = event.target.value;
+    refresh();
+  });
+
+  sortName.addEventListener("click", () => {
+    state.sortBy = "name";
+    refresh();
+  });
+
+  sortCity.addEventListener("click", () => {
+    state.sortBy = "city";
+    refresh();
+  });
+
+  refresh();
+};
+
+init();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,46 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f7f9fc;
+  color: #0f172a;
+}
+
+.container {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+input {
+  width: 100%;
+  margin: 0.75rem 0 1rem;
+  padding: 0.65rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  padding: 0.75rem;
+}
+
+th button {
+  border: none;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: #1d4ed8;
+  font-weight: 600;
+}

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getVisibleRows } from "../src/main.js";
+
+test("getVisibleRows filters by query and sorts by city", () => {
+  const rows = [
+    { name: "Yui", role: "Engineer", city: "Denver" },
+    { name: "Ana", role: "PM", city: "Austin" }
+  ];
+
+  const result = getVisibleRows(rows, "", "city");
+  assert.equal(result[0].city, "Austin");
+});


### PR DESCRIPTION
### Motivation
- Provide a small, reviewable vertical slice that ships a runnable static frontend and enforces repository automation for follow-up work.
- Wire the project's canonical commands so `make ci` performs a deterministic install, checks, and static build for GitHub-native hosting.
- Keep the change small and reversible while adding an Evidence Pack documenting verification steps and results.

### Description
- Add working Makefile targets `setup`, `fmt`, `lint`, `test`, `build`, `ci`, and `dev` so `make ci` runs install + checks + build and `make dev` serves `dist/` locally.  
- Add npm metadata (`package.json`, `package-lock.json`) and lightweight Node scripts in `scripts/` for `fmt`, `lint`, and `build` to produce `dist/`.  
- Bootstrap a minimal static frontend under `src/` (`index.html`, `main.js`, `styles.css`) that renders a sortable, filterable table and exports `getVisibleRows` for testability.  
- Add a smoke test at `tests/smoke.test.mjs`, `.gitignore` entries, and the Evidence Pack at `docs/evidence/ISSUE-7-interactive-table-bootstrap.md`.  
- Fixes #7

### Testing
- Ran `make ci` locally which completed successfully (tests passed and `build` produced `dist/`) and the Evidence Pack records the output.  
- Ran `make dev` and served `dist/` via `python3 -m http.server` and validated the UI with an automated Playwright screenshot.  
- The unit smoke test `tests/smoke.test.mjs` ran under `node --test` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f41406d88328a89084a6af614739)