### PR TITLE
Add per-column sorting (ascending/descending) with stable behavior

### DIFF
--- a/docs/evidence/ISSUE-11-column-sorting.md
+++ b/docs/evidence/ISSUE-11-column-sorting.md
@@ -1,0 +1,32 @@
+# Evidence Pack — Add per-column sorting (ascending/descending) with stable behavior
+
+## What changed
+- Added reusable sorting utilities for deterministic sort toggling (`none -> asc -> desc -> none`) and stable ordering with original-index tie breaks.
+- Updated table UI to make Name, Role, and City headers sortable with visible indicators (`↕`, `▲`, `▼`).
+- Added tests for numeric and text sorting, sort stability, non-mutation, and toggle behavior.
+
+## Why
+- Issue #11 requires per-column ascending/descending sorting with predictable toggles and stable behavior while preserving source dataset immutability.
+
+## How to verify
+### Automated
+- `make ci`:
+  - Result: PASS
+  - Notes: Runs install, format, lint, tests, and build successfully.
+
+### Manual (if needed)
+- Steps:
+  1. Run `make dev`.
+  2. Open `http://localhost:4173`.
+  3. Click Name / Role / City headers repeatedly and observe icon/state cycles.
+  4. Verify row order updates immediately and ties remain in original relative order.
+- Expected:
+  - Active column cycles `↕ -> ▲ -> ▼ -> ↕`.
+  - Sorting is deterministic and stable.
+
+## Risk assessment
+- Risk level: low
+- Potential regressions:
+  - Header-label updates or sort-state transitions could drift from expected icon cycle.
+- Rollback plan:
+  - Revert this PR commit to restore previous unsorted/legacy behavior.

--- a/src/index.html
+++ b/src/index.html
@@ -23,9 +23,9 @@
       <table>
         <thead>
           <tr>
-            <th><button id="sortName" type="button">Name</button></th>
-            <th>Role</th>
-            <th><button id="sortCity" type="button">City</button></th>
+            <th><button type="button" data-sort-column="name" data-label="Name">Name ↕</button></th>
+            <th><button type="button" data-sort-column="role" data-label="Role">Role ↕</button></th>
+            <th><button type="button" data-sort-column="city" data-label="City">City ↕</button></th>
           </tr>
         </thead>
         <tbody id="tableBody"></tbody>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { initCsvUpload } from "./upload.js";
+import { SORT_DIRECTIONS, sortRows, toggleSort } from "./sort.js";
 
 const people = [
   { name: "Ari", role: "Engineer", city: "Seattle" },
@@ -8,22 +9,44 @@ const people = [
 ];
 
 const state = {
-  sortBy: "name",
+  sort: { column: null, direction: SORT_DIRECTIONS.NONE },
   query: ""
 };
 
-export const getVisibleRows = (rows, query, sortBy) =>
-  rows
-    .filter((row) => {
-      const haystack = `${row.name} ${row.city}`.toLowerCase();
-      return haystack.includes(query.trim().toLowerCase());
-    })
-    .toSorted((a, b) => a[sortBy].localeCompare(b[sortBy]));
+export const getVisibleRows = (rows, query, sort) => {
+  const filteredRows = rows.filter((row) => {
+    const haystack = `${row.name} ${row.city}`.toLowerCase();
+    return haystack.includes(query.trim().toLowerCase());
+  });
+
+  return sortRows(filteredRows, sort);
+};
 
 export const renderRows = (rows, target) => {
   target.innerHTML = rows
     .map((row) => `<tr><td>${row.name}</td><td>${row.role}</td><td>${row.city}</td></tr>`)
     .join("");
+};
+
+const SORT_SYMBOLS = {
+  [SORT_DIRECTIONS.NONE]: "↕",
+  [SORT_DIRECTIONS.ASC]: "▲",
+  [SORT_DIRECTIONS.DESC]: "▼"
+};
+
+const renderSortControls = (buttons, sortState) => {
+  buttons.forEach((button) => {
+    const column = button.dataset.sortColumn;
+    const isActiveColumn = sortState.column === column;
+    const direction = isActiveColumn ? sortState.direction : SORT_DIRECTIONS.NONE;
+    const symbol = SORT_SYMBOLS[direction];
+
+    button.textContent = `${button.dataset.label} ${symbol}`;
+    button.setAttribute(
+      "aria-label",
+      `${button.dataset.label} sorting ${direction === SORT_DIRECTIONS.NONE ? "off" : direction}`
+    );
+  });
 };
 
 const init = () => {
@@ -33,30 +56,29 @@ const init = () => {
 
   const tableBody = document.querySelector("#tableBody");
   const search = document.querySelector("#search");
-  const sortName = document.querySelector("#sortName");
-  const sortCity = document.querySelector("#sortCity");
+  const sortButtons = [...document.querySelectorAll("[data-sort-column]")];
   const csvUpload = document.querySelector("#csvUpload");
   const uploadStatus = document.querySelector("#uploadStatus");
 
-  if (!tableBody || !search || !sortName || !sortCity) {
+  if (!tableBody || !search || sortButtons.length === 0) {
     return;
   }
 
-  const refresh = () => renderRows(getVisibleRows(people, state.query, state.sortBy), tableBody);
+  const refresh = () => {
+    renderRows(getVisibleRows(people, state.query, state.sort), tableBody);
+    renderSortControls(sortButtons, state.sort);
+  };
 
   search.addEventListener("input", (event) => {
     state.query = event.target.value;
     refresh();
   });
 
-  sortName.addEventListener("click", () => {
-    state.sortBy = "name";
-    refresh();
-  });
-
-  sortCity.addEventListener("click", () => {
-    state.sortBy = "city";
-    refresh();
+  sortButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      state.sort = toggleSort(state.sort, button.dataset.sortColumn);
+      refresh();
+    });
   });
 
   initCsvUpload({ input: csvUpload, status: uploadStatus });

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,0 +1,50 @@
+export const SORT_DIRECTIONS = {
+  NONE: "none",
+  ASC: "asc",
+  DESC: "desc"
+};
+
+const nextDirection = {
+  [SORT_DIRECTIONS.NONE]: SORT_DIRECTIONS.ASC,
+  [SORT_DIRECTIONS.ASC]: SORT_DIRECTIONS.DESC,
+  [SORT_DIRECTIONS.DESC]: SORT_DIRECTIONS.NONE
+};
+
+export const toggleSort = (currentSort, column) => {
+  if (currentSort.column !== column) {
+    return { column, direction: SORT_DIRECTIONS.ASC };
+  }
+
+  const direction = nextDirection[currentSort.direction] ?? SORT_DIRECTIONS.NONE;
+  return direction === SORT_DIRECTIONS.NONE
+    ? { column: null, direction: SORT_DIRECTIONS.NONE }
+    : { column, direction };
+};
+
+const compareValues = (left, right) => {
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+
+  return String(left).localeCompare(String(right));
+};
+
+export const sortRows = (rows, sortState) => {
+  if (!sortState.column || sortState.direction === SORT_DIRECTIONS.NONE) {
+    return [...rows];
+  }
+
+  const directionMultiplier = sortState.direction === SORT_DIRECTIONS.DESC ? -1 : 1;
+
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      const comparison = compareValues(left.row[sortState.column], right.row[sortState.column]);
+      if (comparison !== 0) {
+        return comparison * directionMultiplier;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.row);
+};

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -2,12 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { getVisibleRows } from "../src/main.js";
 
-test("getVisibleRows filters by query and sorts by city", () => {
+test("getVisibleRows filters by query and sorts by requested column", () => {
   const rows = [
     { name: "Yui", role: "Engineer", city: "Denver" },
     { name: "Ana", role: "PM", city: "Austin" }
   ];
 
-  const result = getVisibleRows(rows, "", "city");
+  const result = getVisibleRows(rows, "", { column: "city", direction: "asc" });
   assert.equal(result[0].city, "Austin");
 });

--- a/tests/sort.test.mjs
+++ b/tests/sort.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SORT_DIRECTIONS, sortRows, toggleSort } from "../src/sort.js";
+
+test("sortRows sorts numeric values ascending and descending", () => {
+  const rows = [{ score: 2 }, { score: 10 }, { score: 1 }];
+
+  const asc = sortRows(rows, { column: "score", direction: SORT_DIRECTIONS.ASC });
+  const desc = sortRows(rows, { column: "score", direction: SORT_DIRECTIONS.DESC });
+
+  assert.deepEqual(
+    asc.map((row) => row.score),
+    [1, 2, 10]
+  );
+  assert.deepEqual(
+    desc.map((row) => row.score),
+    [10, 2, 1]
+  );
+});
+
+test("sortRows is stable and does not mutate source data", () => {
+  const rows = [
+    { name: "Ari", city: "Austin" },
+    { name: "Bea", city: "Austin" },
+    { name: "Cam", city: "Boston" }
+  ];
+
+  const sorted = sortRows(rows, { column: "city", direction: SORT_DIRECTIONS.ASC });
+
+  assert.deepEqual(
+    sorted.map((row) => row.name),
+    ["Ari", "Bea", "Cam"]
+  );
+  assert.notEqual(sorted, rows);
+});
+
+test("toggleSort cycles none -> asc -> desc -> none and resets on new column", () => {
+  const start = { column: null, direction: SORT_DIRECTIONS.NONE };
+  const asc = toggleSort(start, "name");
+  const desc = toggleSort(asc, "name");
+  const none = toggleSort(desc, "name");
+  const cityAsc = toggleSort(desc, "city");
+
+  assert.deepEqual(asc, { column: "name", direction: SORT_DIRECTIONS.ASC });
+  assert.deepEqual(desc, { column: "name", direction: SORT_DIRECTIONS.DESC });
+  assert.deepEqual(none, { column: null, direction: SORT_DIRECTIONS.NONE });
+  assert.deepEqual(cityAsc, { column: "city", direction: SORT_DIRECTIONS.ASC });
+});


### PR DESCRIPTION
Fixes #11

## Summary
- add per-column sort state cycling (none -> asc -> desc -> none)
- implement stable, non-mutating sort utility for text and numeric values
- update table headers to sort Name/Role/City with visible indicators
- add tests for sort behavior and update smoke coverage
- add Evidence Pack for issue #11 with make ci results
