### PR TITLE
Add per-column text filtering with composable filters

### DIFF
--- a/docs/evidence/ISSUE-12-column-filtering.md
+++ b/docs/evidence/ISSUE-12-column-filtering.md
@@ -1,0 +1,37 @@
+# Evidence Pack — Add per-column text filtering with composable filters
+
+## What changed
+- Added per-column text filters for Name, Role, and City with dedicated clear (`×`) buttons in the table header.
+- Added a global **Clear all filters** action that resets all filter inputs and clears sort state.
+- Updated table state logic to compose all active column filters with existing sort behavior.
+- Added tests for single-column filtering, composed multi-column filtering, filtering+sorting interaction, and reset behavior.
+
+## Why
+- Issue #12 requires composable per-column text filtering that works together with sorting and can be cleared quickly by users.
+
+## How to verify
+### Automated
+- `make ci`:
+  - Result: PASS
+  - Notes: Runs setup, formatting, lint, tests, and build successfully.
+
+### Manual (if needed)
+- Steps:
+  1. Run `make dev` and open `http://127.0.0.1:4173`.
+  2. Enter `engine` in Role filter and `austin` in City filter.
+  3. Confirm only matching rows remain visible.
+  4. Click a sortable header to sort filtered rows.
+  5. Click a per-column `×` clear button and verify that filter is removed.
+  6. Click **Clear all filters** and verify all filters and sort indicators reset.
+- Expected:
+  - Filters apply cumulatively across columns.
+  - Sorting works on the currently filtered row set.
+  - Clear controls reset filtered state as described.
+
+## Risk assessment
+- Risk level: low
+- Potential regressions:
+  - Incorrect filter wiring for a specific column could hide expected rows.
+  - UI state could desync if future columns are added without updating the column list.
+- Rollback plan:
+  - Revert this PR commit to restore prior single-query filter behavior.

--- a/src/index.html
+++ b/src/index.html
@@ -18,14 +18,28 @@
         <p id="uploadStatus" role="status" aria-live="polite">No file selected yet.</p>
       </section>
 
-      <label for="search">Filter rows</label>
-      <input id="search" type="search" placeholder="Type to filter by name or city" />
+      <button id="clearAllFilters" type="button">Clear all filters</button>
+
       <table>
         <thead>
           <tr>
             <th><button type="button" data-sort-column="name" data-label="Name">Name ↕</button></th>
             <th><button type="button" data-sort-column="role" data-label="Role">Role ↕</button></th>
             <th><button type="button" data-sort-column="city" data-label="City">City ↕</button></th>
+          </tr>
+          <tr>
+            <th>
+              <input data-filter-column="name" type="search" placeholder="Filter name" aria-label="Filter name" />
+              <button type="button" data-clear-filter="name" aria-label="Clear name filter">×</button>
+            </th>
+            <th>
+              <input data-filter-column="role" type="search" placeholder="Filter role" aria-label="Filter role" />
+              <button type="button" data-clear-filter="role" aria-label="Clear role filter">×</button>
+            </th>
+            <th>
+              <input data-filter-column="city" type="search" placeholder="Filter city" aria-label="Filter city" />
+              <button type="button" data-clear-filter="city" aria-label="Clear city filter">×</button>
+            </th>
           </tr>
         </thead>
         <tbody id="tableBody"></tbody>

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,6 +54,10 @@ input {
   padding: 0.65rem;
 }
 
+#clearAllFilters {
+  margin-bottom: 0.8rem;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -74,4 +78,14 @@ th button {
   font: inherit;
   color: #1d4ed8;
   font-weight: 600;
+}
+
+th input[data-filter-column] {
+  margin: 0.5rem 0;
+  width: calc(100% - 2rem);
+}
+
+th button[data-clear-filter] {
+  padding: 0.2rem 0.4rem;
+  color: #334155;
 }

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -1,13 +1,43 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getVisibleRows } from "../src/main.js";
+import { applyColumnFilters, getVisibleRows } from "../src/main.js";
+import { SORT_DIRECTIONS } from "../src/sort.js";
 
-test("getVisibleRows filters by query and sorts by requested column", () => {
-  const rows = [
-    { name: "Yui", role: "Engineer", city: "Denver" },
-    { name: "Ana", role: "PM", city: "Austin" }
-  ];
+const rows = [
+  { name: "Yui", role: "Engineer", city: "Denver" },
+  { name: "Ana", role: "PM", city: "Austin" },
+  { name: "Ben", role: "Engineer", city: "Austin" }
+];
 
-  const result = getVisibleRows(rows, "", { column: "city", direction: "asc" });
-  assert.equal(result[0].city, "Austin");
+test("applyColumnFilters supports single and multi-column filtering", () => {
+  const single = applyColumnFilters(rows, { name: "", role: "engine", city: "" });
+  const composed = applyColumnFilters(rows, { name: "b", role: "engine", city: "austin" });
+
+  assert.deepEqual(
+    single.map((row) => row.name),
+    ["Yui", "Ben"]
+  );
+  assert.deepEqual(
+    composed.map((row) => row.name),
+    ["Ben"]
+  );
+});
+
+test("getVisibleRows composes filtering with sorting and clears when filters reset", () => {
+  const filteredAndSorted = getVisibleRows(
+    rows,
+    { name: "", role: "", city: "austin" },
+    { column: "name", direction: SORT_DIRECTIONS.DESC }
+  );
+  const resetFilters = getVisibleRows(
+    rows,
+    { name: "", role: "", city: "" },
+    { column: null, direction: SORT_DIRECTIONS.NONE }
+  );
+
+  assert.deepEqual(
+    filteredAndSorted.map((row) => row.name),
+    ["Ben", "Ana"]
+  );
+  assert.equal(resetFilters.length, rows.length);
 });


### PR DESCRIPTION
Fixes #12

## Summary
- add per-column text inputs in the table header for name, role, and city
- apply filters cumulatively and compose filtering with existing sort behavior
- add per-column clear controls and a global clear-all action (resets filters + sort)
- add/update tests and issue evidence pack with make ci results

## Testing
- make ci