### PR TITLE
Expand unit coverage for interactive table core behaviors

### DIFF
--- a/docs/evidence/ISSUE-62-expand-unit-coverage.md
+++ b/docs/evidence/ISSUE-62-expand-unit-coverage.md
@@ -1,0 +1,30 @@
+# Evidence Pack — Expand unit coverage for interactive table core behaviors
+
+## What changed
+- Added `tests/coreBehaviors.test.mjs` with focused unit tests that cover core logic pathways for sorting, filtering, memoized visibility selection, and chunked row rendering behavior.
+- Extended edge-case validation for empty datasets, null/undefined values, mixed value types, and sort state transition fallback from invalid direction values.
+- Updated `package.json` unit-test command so the new test file runs in the merge-gating test suite.
+
+## Why
+- Issue #62 asks for broader and faster unit-level coverage of table core logic (sorting, filtering, pagination-like chunking behavior, and state transitions), including edge-case inputs.
+- These tests add confidence in business-logic invariants without adding slow integration overhead.
+
+## How to verify
+### Automated
+- `make ci`:
+  - Result: pass
+  - Notes: formatting, linting, full unit tests (including new core behavior tests), smoke tests, and build checks all completed successfully.
+
+### Manual (if needed)
+- Steps:
+  1. Inspect `tests/coreBehaviors.test.mjs` for the new behavior coverage categories.
+  2. Run `npm run test:unit` and verify all tests pass.
+- Expected:
+  - New tests execute quickly and pass consistently while covering edge cases called out in issue scope.
+
+## Risk assessment
+- Risk level: low
+- Potential regressions:
+  - Minimal production risk because changes are test-only plus test command wiring.
+- Rollback plan:
+  - Revert this PR to restore the prior unit test surface.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:unit && npm run test:smoke",
     "build": "node scripts/build.mjs",
     "dev": "npm run build && python3 -m http.server 4173 --directory dist",
-    "test:unit": "node --test tests/csvParser.test.mjs tests/fixtures.test.mjs tests/sort.test.mjs tests/tableRenderer.test.mjs tests/upload.test.mjs tests/performance.test.mjs",
+    "test:unit": "node --test tests/coreBehaviors.test.mjs tests/csvParser.test.mjs tests/fixtures.test.mjs tests/sort.test.mjs tests/tableRenderer.test.mjs tests/upload.test.mjs tests/performance.test.mjs",
     "test:smoke": "node --test tests/smoke.test.mjs"
   }
 }

--- a/tests/coreBehaviors.test.mjs
+++ b/tests/coreBehaviors.test.mjs
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyColumnFilters, getVisibleRows, renderRowsChunked } from "../src/main.js";
+import { SORT_DIRECTIONS, sortRows, toggleSort } from "../src/sort.js";
+
+test("sortRows handles empty data and mixed/nullish values without mutating source", () => {
+  assert.deepEqual(sortRows([], { column: "name", direction: SORT_DIRECTIONS.ASC }), []);
+
+  const rows = [
+    { name: "Zed", score: null },
+    { name: "Ana", score: 2 },
+    { name: "Bob", score: undefined },
+    { name: "Cam", score: "10" }
+  ];
+
+  const asc = sortRows(rows, { column: "score", direction: SORT_DIRECTIONS.ASC });
+  const desc = sortRows(rows, { column: "score", direction: SORT_DIRECTIONS.DESC });
+
+  assert.deepEqual(
+    asc.map((row) => row.name),
+    ["Cam", "Ana", "Zed", "Bob"]
+  );
+  assert.deepEqual(
+    desc.map((row) => row.name),
+    ["Bob", "Zed", "Ana", "Cam"]
+  );
+  assert.deepEqual(
+    rows.map((row) => row.name),
+    ["Zed", "Ana", "Bob", "Cam"]
+  );
+});
+
+test("applyColumnFilters supports trimmed case-insensitive queries with nullish cell values", () => {
+  const rows = [
+    { name: "Ari", role: "Engineer", city: null },
+    { name: "Bea", role: undefined, city: "Austin" },
+    { name: "Cam", role: "Designer", city: "Boston" }
+  ];
+
+  const filtered = applyColumnFilters(rows, { name: "  a  ", role: "", city: "" });
+  const nullishMatch = applyColumnFilters(rows, { name: "", role: "", city: "null" });
+
+  assert.deepEqual(
+    filtered.map((row) => row.name),
+    ["Ari", "Bea", "Cam"]
+  );
+  assert.deepEqual(
+    nullishMatch.map((row) => row.name),
+    []
+  );
+});
+
+test("toggleSort falls back to NONE on unknown direction before restarting cycle", () => {
+  const invalid = { column: "name", direction: "sideways" };
+  const reset = toggleSort(invalid, "name");
+  const asc = toggleSort(reset, "name");
+
+  assert.deepEqual(reset, { column: null, direction: SORT_DIRECTIONS.NONE });
+  assert.deepEqual(asc, { column: "name", direction: SORT_DIRECTIONS.ASC });
+});
+
+test("getVisibleRows memoizes by reference and recomputes when inputs change", () => {
+  const rows = [
+    { name: "Ari", role: "Engineer", city: "Seattle" },
+    { name: "Bea", role: "PM", city: "Austin" }
+  ];
+  const filters = { name: "", role: "", city: "" };
+  const sort = { column: "name", direction: SORT_DIRECTIONS.ASC };
+
+  const first = getVisibleRows(rows, filters, sort);
+  const second = getVisibleRows(rows, filters, sort);
+
+  assert.equal(first, second);
+
+  const nextFilters = { ...filters, city: "austin" };
+  const next = getVisibleRows(rows, nextFilters, sort);
+
+  assert.notEqual(first, next);
+  assert.deepEqual(
+    next.map((row) => row.name),
+    ["Bea"]
+  );
+});
+
+test("renderRowsChunked appends chunks and stops when cancellation token flips", async () => {
+  const rows = [
+    { name: "A", role: "R1", city: "C1" },
+    { name: "B", role: "R2", city: "C2" },
+    { name: "C", role: "R3", city: "C3" }
+  ];
+
+  const target = {
+    innerHTML: "stale",
+    insertAdjacentHTML(_position, html) {
+      this.innerHTML += html;
+    }
+  };
+
+  let scheduleCount = 0;
+  await renderRowsChunked(rows, target, {
+    chunkSize: 2,
+    schedule: async () => {
+      scheduleCount += 1;
+    }
+  });
+
+  assert.equal(scheduleCount, 2);
+  assert.match(target.innerHTML, /<td>A<\/td>/);
+  assert.match(target.innerHTML, /<td>C<\/td>/);
+
+  const cancelledTarget = {
+    innerHTML: "",
+    insertAdjacentHTML(_position, html) {
+      this.innerHTML += html;
+    }
+  };
+
+  let cancelled = false;
+  await renderRowsChunked(rows, cancelledTarget, {
+    chunkSize: 1,
+    schedule: async () => {
+      cancelled = true;
+    },
+    isCancelled: () => cancelled
+  });
+
+  assert.match(cancelledTarget.innerHTML, /<td>A<\/td>/);
+  assert.doesNotMatch(cancelledTarget.innerHTML, /<td>B<\/td>/);
+});


### PR DESCRIPTION
Fixes #62\n\n## Summary\n- add focused unit tests for sorting, filtering, memoization, and chunked rendering behaviors\n- cover edge cases for empty datasets, mixed/nullish values, and invalid sort direction transitions\n- update the issue evidence pack with verification notes and CI results