### PR TITLE
Add unit tests for column configuration and rendering contracts

### DIFF
--- a/docs/evidence/ISSUE-63-column-config-rendering-contracts.md
+++ b/docs/evidence/ISSUE-63-column-config-rendering-contracts.md
@@ -1,0 +1,30 @@
+# Evidence Pack — Add unit tests for column configuration and rendering contracts
+
+## What changed
+- Added `src/columnConfig.js` with focused helpers to normalize column configuration (visibility, ordering, defaults) and resolve rendered cell content from value mapping, formatters, and renderers.
+- Added `tests/columnConfig.test.mjs` to cover regression-prone column configuration and rendering contract behavior, including missing keys and invalid renderer outputs.
+- Updated `package.json` so the new unit test file runs in the merge-gating unit test suite.
+
+## Why
+- Issue #63 requires unit-level coverage for column configuration behavior and rendering contracts without browser runtime dependencies.
+- The new tests protect logic around visibility/order defaults, mapped values, formatter/renderer sequencing, and invalid renderer return handling.
+
+## How to verify
+### Automated
+- `make ci`:
+  - Result: pass
+  - Notes: formatting, linting, all unit tests (including the new column configuration suite), smoke tests, and build checks passed.
+
+### Manual (if needed)
+- Steps:
+  1. Review `tests/columnConfig.test.mjs` for the acceptance-criteria scenarios.
+  2. Run `npm run test:unit` and confirm the column config tests execute and pass.
+- Expected:
+  - Column behavior contracts remain deterministic and covered by fast unit tests.
+
+## Risk assessment
+- Risk level: low
+- Potential regressions:
+  - Low runtime risk because this change is additive (new helper + tests) and does not alter production wiring.
+- Rollback plan:
+  - Revert this PR to remove the additive helper and tests if needed.

--- a/docs/evidence/ISSUE-63-column-config-rendering-contracts.md
+++ b/docs/evidence/ISSUE-63-column-config-rendering-contracts.md
@@ -3,6 +3,7 @@
 ## What changed
 - Added `src/columnConfig.js` with focused helpers to normalize column configuration (visibility, ordering, defaults) and resolve rendered cell content from value mapping, formatters, and renderers.
 - Added `tests/columnConfig.test.mjs` to cover regression-prone column configuration and rendering contract behavior, including missing keys and invalid renderer outputs.
+- Hardened callback handling so `undefined`/non-function `formatter` or `renderer` values now safely fall back to defaults instead of throwing at runtime.
 - Updated `package.json` so the new unit test file runs in the merge-gating unit test suite.
 
 ## Why

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:unit && npm run test:smoke",
     "build": "node scripts/build.mjs",
     "dev": "npm run build && python3 -m http.server 4173 --directory dist",
-    "test:unit": "node --test tests/coreBehaviors.test.mjs tests/csvParser.test.mjs tests/fixtures.test.mjs tests/sort.test.mjs tests/tableRenderer.test.mjs tests/upload.test.mjs tests/performance.test.mjs",
+    "test:unit": "node --test tests/columnConfig.test.mjs tests/coreBehaviors.test.mjs tests/csvParser.test.mjs tests/fixtures.test.mjs tests/sort.test.mjs tests/tableRenderer.test.mjs tests/upload.test.mjs tests/performance.test.mjs",
     "test:smoke": "node --test tests/smoke.test.mjs"
   }
 }

--- a/src/columnConfig.js
+++ b/src/columnConfig.js
@@ -6,6 +6,9 @@ const defaultColumn = {
   renderer: DEFAULT_RENDERER
 };
 
+const resolveCallback = (candidate, fallback) =>
+  typeof candidate === "function" ? candidate : fallback;
+
 export const normalizeColumns = (columns = []) =>
   columns
     .filter((column) => column && typeof column.key === "string" && column.key.length > 0)
@@ -18,9 +21,11 @@ export const normalizeColumns = (columns = []) =>
     .filter((column) => column.visible);
 
 const renderCellValue = (column, row) => {
+  const formatter = resolveCallback(column.formatter, defaultColumn.formatter);
+  const renderer = resolveCallback(column.renderer, defaultColumn.renderer);
   const mapped = column.value ? column.value(row) : row[column.key];
-  const formatted = column.formatter(mapped, row);
-  const rendered = column.renderer(formatted, row);
+  const formatted = formatter(mapped, row);
+  const rendered = renderer(formatted, row);
 
   return typeof rendered === "string" ? rendered : DEFAULT_RENDERER(rendered);
 };

--- a/src/columnConfig.js
+++ b/src/columnConfig.js
@@ -1,0 +1,32 @@
+const DEFAULT_RENDERER = (value) => (value == null ? "" : String(value));
+
+const defaultColumn = {
+  visible: true,
+  formatter: (value) => value,
+  renderer: DEFAULT_RENDERER
+};
+
+export const normalizeColumns = (columns = []) =>
+  columns
+    .filter((column) => column && typeof column.key === "string" && column.key.length > 0)
+    .map((column, index) => ({
+      ...defaultColumn,
+      ...column,
+      order: Number.isFinite(column.order) ? column.order : index
+    }))
+    .sort((left, right) => left.order - right.order)
+    .filter((column) => column.visible);
+
+const renderCellValue = (column, row) => {
+  const mapped = column.value ? column.value(row) : row[column.key];
+  const formatted = column.formatter(mapped, row);
+  const rendered = column.renderer(formatted, row);
+
+  return typeof rendered === "string" ? rendered : DEFAULT_RENDERER(rendered);
+};
+
+export const renderRowCells = (columns, row) =>
+  normalizeColumns(columns).map((column) => ({
+    key: column.key,
+    content: renderCellValue(column, row)
+  }));

--- a/tests/columnConfig.test.mjs
+++ b/tests/columnConfig.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeColumns, renderRowCells } from "../src/columnConfig.js";
+
+test("normalizeColumns keeps valid columns, applies defaults, and sorts by order", () => {
+  const normalized = normalizeColumns([
+    null,
+    { key: "city", order: 2 },
+    { key: "name", order: 0 },
+    { key: "role", order: 1, visible: false },
+    { key: "" }
+  ]);
+
+  assert.deepEqual(
+    normalized.map(({ key, order, visible }) => ({ key, order, visible })),
+    [
+      { key: "name", order: 0, visible: true },
+      { key: "city", order: 2, visible: true }
+    ]
+  );
+});
+
+test("normalizeColumns preserves insertion order when order is missing", () => {
+  const normalized = normalizeColumns([{ key: "name" }, { key: "role" }, { key: "city" }]);
+
+  assert.deepEqual(
+    normalized.map(({ key, order }) => ({ key, order })),
+    [
+      { key: "name", order: 0 },
+      { key: "role", order: 1 },
+      { key: "city", order: 2 }
+    ]
+  );
+});
+
+test("renderRowCells supports value mapping, formatting, and renderer contracts", () => {
+  const row = { name: "Ari", role: "engineer", city: "Seattle" };
+
+  const cells = renderRowCells(
+    [
+      { key: "name", renderer: (value) => `<strong>${value}</strong>` },
+      {
+        key: "role",
+        value: (record) => record.role,
+        formatter: (value) => value.toUpperCase(),
+        renderer: (value) => `Role: ${value}`
+      }
+    ],
+    row
+  );
+
+  assert.deepEqual(cells, [
+    { key: "name", content: "<strong>Ari</strong>" },
+    { key: "role", content: "Role: ENGINEER" }
+  ]);
+});
+
+test("renderRowCells falls back to safe string conversion for invalid renderer output", () => {
+  const row = { name: "Ari", role: null, city: "Seattle" };
+
+  const cells = renderRowCells(
+    [
+      { key: "name", renderer: () => 42 },
+      { key: "role" },
+      { key: "city", visible: false }
+    ],
+    row
+  );
+
+  assert.deepEqual(cells, [
+    { key: "name", content: "42" },
+    { key: "role", content: "" }
+  ]);
+});

--- a/tests/columnConfig.test.mjs
+++ b/tests/columnConfig.test.mjs
@@ -72,3 +72,12 @@ test("renderRowCells falls back to safe string conversion for invalid renderer o
     { key: "role", content: "" }
   ]);
 });
+
+
+test("renderRowCells uses default callbacks when formatter/renderer are undefined", () => {
+  const row = { name: "Ari" };
+
+  const cells = renderRowCells([{ key: "name", formatter: undefined, renderer: undefined }], row);
+
+  assert.deepEqual(cells, [{ key: "name", content: "Ari" }]);
+});


### PR DESCRIPTION
Fixes #63\n\n## Summary\n- add a column configuration helper that normalizes visibility, ordering, and default formatter/renderer behavior\n- add unit tests for column configuration and rendering contracts, including missing keys and invalid renderer output\n- update the Evidence Pack with verification outcomes and risk notes\n\n## Validation\n- make ci